### PR TITLE
feat: Locale에 따른 market과 language 설정 추가

### DIFF
--- a/app/src/main/java/com/stopstone/musicplaylist/data/remote/api/SpotifyApi.kt
+++ b/app/src/main/java/com/stopstone/musicplaylist/data/remote/api/SpotifyApi.kt
@@ -4,6 +4,7 @@ import com.stopstone.musicplaylist.data.model.entity.AudioFeatures
 import com.stopstone.musicplaylist.data.model.response.RecommendationsResponse
 import com.stopstone.musicplaylist.data.model.response.SearchResponse
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -11,7 +12,9 @@ interface SpotifyApi {
     @GET("v1/search")
     suspend fun searchTracks(
         @Query("q") query: String,
-        @Query("type") type: String = "track"
+        @Query("type") type: String = "track",
+        @Query("market") market: String,
+        @Header("Accept-Language") language: String
     ): SearchResponse
 
     @GET("v1/audio-features/{id}")

--- a/app/src/main/java/com/stopstone/musicplaylist/data/repository/search/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/stopstone/musicplaylist/data/repository/search/SearchRepositoryImpl.kt
@@ -5,26 +5,31 @@ import com.stopstone.musicplaylist.data.model.Emotions
 import com.stopstone.musicplaylist.data.remote.api.SpotifyApi
 import com.stopstone.musicplaylist.data.model.response.Track
 import com.stopstone.musicplaylist.domain.repository.search.SearchRepository
+import java.util.Locale
 import javax.inject.Inject
 
 class SearchRepositoryImpl @Inject constructor(
     private val spotifyApi: SpotifyApi,
-) : SearchRepository {
-
-    override suspend fun searchTracks(query: String): List<Track> {
-        Log.d("SearchRepositoryImpl", "쿼리로 트랙 검색 중: $query")
-
-        return try {
-            val response = spotifyApi.searchTracks(query)
-            Log.d("SearchRepositoryImpl", "응답: $response")
-            response.tracks.items
-        } catch (e: Exception) {
-            Log.e("SearchRepositoryImpl", "트랙 검색 중 오류 발생", e)
-            emptyList()
-        }
+): SearchRepository {
+    override suspend fun searchTracks(query: String): List<Track> = try {
+        val (market, language) = getMarketLanguageByLocale()
+        val response = spotifyApi.searchTracks(
+            query = query,
+            market = market,
+            language = language
+        )
+        response.tracks.items
+    } catch (e: Exception) {
+        Log.e("SearchRepositoryImpl", "트랙 검색 중 오류 발생", e)
+        emptyList()
     }
 
     override suspend fun getEmotions(): List<Emotions> {
         return Emotions.entries
+    }
+
+    private fun getMarketLanguageByLocale() = when (Locale.getDefault().language) {
+        "ko" -> Pair("KR", "ko-KR")
+        else -> Pair("US", "en-US")
     }
 }


### PR DESCRIPTION
 - 한국어: market="KR", language="ko-KR"
 - 영어: market="US", language="en-US"
- 검색 결과의 지역화 및 언어 최적화를 위한 Pair 객체 활용