### PR TITLE
[FEAT] Firebase Crashlytics 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("androidx.navigation.safeargs.kotlin")
     id("kotlin-parcelize")
     alias(libs.plugins.google.gms.google.services)
+    alias(libs.plugins.google.firebase.crashlytics)
 }
 
 val localPropertiesFile = rootProject.file("local.properties")
@@ -107,6 +108,7 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.firestore)
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
 
     // WorkManager
     implementation(libs.androidx.work.runtime.ktx)

--- a/app/src/main/java/com/stopstone/musicplaylist/App.kt
+++ b/app/src/main/java/com/stopstone/musicplaylist/App.kt
@@ -3,6 +3,8 @@ package com.stopstone.musicplaylist
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import com.google.firebase.FirebaseApp
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kakao.sdk.common.KakaoSdk
 import com.stopstone.musicplaylist.notification.NotificationChannelManager
 import dagger.hilt.android.HiltAndroidApp
@@ -14,6 +16,14 @@ class App : Application() {
 
         // Firebase 초기화
         FirebaseApp.initializeApp(this)
+
+        // Crashlytics 설정 - 디버그 빌드에서는 비활성화
+        FirebaseCrashlytics.getInstance().apply {
+            isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
+        }
+
+        // Analytics 초기화
+        FirebaseAnalytics.getInstance(this)
 
         // 카카오 SDK 초기화
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)

--- a/app/src/main/java/com/stopstone/musicplaylist/util/StoneLog.kt
+++ b/app/src/main/java/com/stopstone/musicplaylist/util/StoneLog.kt
@@ -1,0 +1,60 @@
+package com.stopstone.musicplaylist.util
+
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.stopstone.musicplaylist.BuildConfig
+
+private const val TAG = "MusicLog"
+
+private fun buildLogMsg(message: String): String {
+    val ste = Thread.currentThread().stackTrace[4]
+    val fileName = ste.fileName.replace(".java", "").replace(".kt", "")
+    return "[$fileName::${ste.methodName} (${ste.fileName}:${ste.lineNumber})]$message"
+}
+
+fun logd(message: String) {
+    if (!BuildConfig.DEBUG) return
+    Log.d(TAG, buildLogMsg(message))
+}
+
+fun logi(message: String) {
+    if (!BuildConfig.DEBUG) return
+    Log.i(TAG, buildLogMsg(message))
+}
+
+fun logw(message: String) {
+    val logMessage = buildLogMsg(message)
+    if (BuildConfig.DEBUG) {
+        Log.w(TAG, logMessage)
+    }
+    FirebaseCrashlytics.getInstance().log(logMessage)
+}
+
+fun loge(message: String) {
+    val logMessage = buildLogMsg(message)
+    if (BuildConfig.DEBUG) {
+        Log.e(TAG, logMessage)
+    }
+    FirebaseCrashlytics.getInstance().log(logMessage)
+}
+
+fun recordException(throwable: Throwable) {
+    if (BuildConfig.DEBUG) {
+        Log.e(TAG, buildLogMsg("Exception: ${throwable.message}"), throwable)
+    }
+    FirebaseCrashlytics.getInstance().recordException(throwable)
+}
+
+fun recordException(
+    message: String,
+    throwable: Throwable,
+) {
+    val logMessage = buildLogMsg("$message: ${throwable.message}")
+    if (BuildConfig.DEBUG) {
+        Log.e(TAG, logMessage, throwable)
+    }
+    FirebaseCrashlytics.getInstance().apply {
+        log(logMessage)
+        recordException(throwable)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.google.dagger.hilt.android") version "2.51.1" apply false
     id("com.google.devtools.ksp") version "1.9.20-1.0.14" apply false
     alias(libs.plugins.google.gms.google.services) apply false
+    alias(libs.plugins.google.firebase.crashlytics) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ googleGmsGoogleServices = "4.4.4"
 firebaseBom = "33.7.0"
 firebaseFirestore = "26.0.2"
 workRuntimeKtx = "2.9.0"
+googleFirebaseCrashlytics = "3.0.6"
 
 [libraries]
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity" }
@@ -61,9 +62,11 @@ v2-all = { module = "com.kakao.sdk:v2-all", version.ref = "v2All" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 google-gms-google-services = { id = "com.google.gms.google-services", version.ref = "googleGmsGoogleServices" }
+google-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "googleFirebaseCrashlytics" }
 


### PR DESCRIPTION
- Firebase Crashlytics를 연동하여 에러를 추적합니다.
- 로그 확장함수를 만들어 에러로그를 자동으로 보고하도록 합니다.